### PR TITLE
Update OpenSDK to Java 1

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
           

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
     - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17
 ARG SBT_VERSION=1.9.9
 
 RUN mkdir /working/ && \


### PR DESCRIPTION
- Updated Dockerfile to use openjdk:17 base image
- Updated GitHub Actions workflows (scala.yml and ci-cd.yml) to use Java 17
- Scala 2.12.20 is fully compatible with Java 17