### PR TITLE
Fix API registration missing password field

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -25,6 +25,13 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
+    - name: Install SBT
+      run: |
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+        sudo apt-get update
+        sudo apt-get install -y sbt
     - name: Run tests
       run: sbt test
       # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,8 +8,6 @@ name: Scala CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,6 +8,8 @@ name: Scala CI
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/openapi.json
+++ b/openapi.json
@@ -59,10 +59,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": ["name", "phoneNumber", "password"],
                 "properties": {
-                  "id": {"type": "string"},
+                  "name": {"type": "string"},
                   "phoneNumber": {"type": "string"},
-                  "name": {"type": "string"}
+                  "password": {"type": "string", "format": "password"}
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -72,6 +72,12 @@
         "responses": {
           "201": {
             "description": "User created successfully"
+          },
+          "400": {
+            "description": "Bad request - invalid input data"
+          },
+          "409": {
+            "description": "Conflict - user already exists"
           }
         }
       }

--- a/src/main/scala/com/geoevent/models/UserModel.scala
+++ b/src/main/scala/com/geoevent/models/UserModel.scala
@@ -1,6 +1,6 @@
 package com.geoevent.models
 
-import spray.json.DefaultJsonProtocol.{BooleanJsonFormat, StringJsonFormat, jsonFormat1, jsonFormat5, seqFormat}
+import spray.json.DefaultJsonProtocol.{BooleanJsonFormat, StringJsonFormat, jsonFormat1, jsonFormat3, jsonFormat5, seqFormat}
 import spray.json.RootJsonFormat
 
 import java.util.UUID
@@ -10,6 +10,10 @@ object UserModel {
 
   case class Users(users: Seq[User])
 
+  // DTO for user registration requests (accepts plain password)
+  case class UserRegistration(name: String, phoneNumber: String, password: String)
+
   implicit val userJsonFormat: RootJsonFormat[User] = jsonFormat5(User)
   implicit val usersJsonFormat: RootJsonFormat[Users] = jsonFormat1(Users)
+  implicit val userRegistrationJsonFormat: RootJsonFormat[UserRegistration] = jsonFormat3(UserRegistration)
 }

--- a/src/main/scala/com/geoevent/routes/UserCalls.scala
+++ b/src/main/scala/com/geoevent/routes/UserCalls.scala
@@ -2,7 +2,7 @@ package com.geoevent.routes
 
 import com.geoevent.Authorization
 import com.geoevent.models.ResponseModels.{ErrorResponse, SuccessResponse}
-import com.geoevent.models.UserModel.User
+import com.geoevent.models.UserModel.{User, UserRegistration}
 import com.geoevent.registies.UserRegistry
 import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
@@ -19,8 +19,16 @@ object UserCalls extends UserRegistry {
     pathPrefix("users") {
       pathEnd {
         post {
-          entity(as[User]) { user =>
-            complete(StatusCodes.Created, HttpEntity(ContentTypes.`application/json`, _create(user.copy(id = UUID.randomUUID.toString)).toJson.compactPrint))
+          entity(as[UserRegistration]) { registration =>
+            // Create User object with password in passwordHash field (will be hashed in registry)
+            val user = User(
+              id = UUID.randomUUID.toString,
+              name = registration.name,
+              phone = registration.phoneNumber,
+              passwordHash = registration.password, // Plain password - will be hashed by _create
+              validated = false
+            )
+            complete(StatusCodes.Created, HttpEntity(ContentTypes.`application/json`, _create(user).toJson.compactPrint))
           }
         }
       } ~

--- a/src/test/scala/com/geoevent/OpenAPISpecTest.scala
+++ b/src/test/scala/com/geoevent/OpenAPISpecTest.scala
@@ -9,7 +9,7 @@ import scala.io.Source
 class OpenAPISpecTest extends AnyFlatSpec with Matchers {
 
   // Load OpenAPI specification
-  val openAPISpecFile = new File("/home/johan/dev/Geoevent-api/openapi.json")
+  val openAPISpecFile = new File("openapi.json")
   val openAPISpecSource = Source.fromFile(openAPISpecFile)
   val openAPISpecJson = try {
     openAPISpecSource.mkString.parseJson.asJsObject

--- a/src/test/scala/com/geoevent/TestFrame.scala
+++ b/src/test/scala/com/geoevent/TestFrame.scala
@@ -2,7 +2,7 @@ package com.geoevent
 
 import com.geoevent.models.AuthModel._
 import com.geoevent.models.ResponseModels.SuccessResponse
-import com.geoevent.models.UserModel.User
+import com.geoevent.models.UserModel.{User, UserRegistration}
 import com.geoevent.routes.{AuthCalls, ChatMessageRoutes, GeoEventRoutes, GeoStampCalls, UserCalls}
 import org.apache.pekko
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
@@ -63,14 +63,12 @@ trait TestFrame extends AnyWordSpec with Matchers with ScalaFutures with Scalate
   }
 
   private def createTestUser(): Unit = {
-    val newUser = User(
-      id = "any",
+    val registration = UserRegistration(
       name = "test_name",
-      phone = phoneNumber,
-      passwordHash = "test_password",
-      validated = false
+      phoneNumber = phoneNumber,
+      password = "test_password"
     )
-    val userEntity = Marshal(newUser).to[MessageEntity].futureValue
+    val userEntity = Marshal(registration).to[MessageEntity].futureValue
     val reqUser = Post("/users").withEntity(userEntity)
 
     testUser = reqUser ~> routes ~> check {


### PR DESCRIPTION
The registration endpoint (POST /users) was missing a password field, causing authentication failures. Users could register but couldn't login because no password was being stored.

Changes:
- Added UserRegistration DTO with name, phoneNumber, and password fields
- Updated UserCalls.userRoutes to accept UserRegistration instead of User
- Map registration data to User model with password in passwordHash field
- Updated OpenAPI spec to document required password field
- Fixed test fixtures to use UserRegistration for creating test users

This enables the complete registration -> login flow to work correctly.