### PR TITLE
Implement user registration and authentication

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -15,6 +15,7 @@
       "post": {
         "summary": "User Authentication",
         "description": "Authenticate user with phone number and password",
+        "security": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -53,6 +54,7 @@
       "post": {
         "summary": "Create User",
         "description": "Create a new user account",
+        "security": [],
         "requestBody": {
           "required": true,
           "content": {


### PR DESCRIPTION
Added "security": [] to /auth and /users POST endpoints to explicitly override the global bearerAuth requirement. These endpoints should not require authentication as they are used for initial user registration and obtaining access tokens.